### PR TITLE
Remove yellow warning banner from transaction popup

### DIFF
--- a/src/popup/views/2-SignSendTransaction.vue
+++ b/src/popup/views/2-SignSendTransaction.vue
@@ -459,11 +459,6 @@
       </div>
     </div>
 
-    <div class="warning-message">
-      Be careful of unknown contracts as they could be malicious. Please
-      interact only with contracts you trust.
-    </div>
-
     <div v-if="!unlocked">
       <Unlock
         @onUnlock="afterUnlocked()"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the always-visible yellow caution banner from the transaction approval popup (`Sign/Send Transaction` view)
- keep all transaction decoding/signing behavior and action buttons unchanged

## Validation
- `yarn lint --no-fix` passes (existing unrelated warnings only)
- `yarn build:ts` passes
- manual UI verification was run on `popup.html#/sendTransaction` to confirm the warning banner is no longer shown
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310ce33c-5aa0-4df7-b42f-09ce3963a1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310ce33c-5aa0-4df7-b42f-09ce3963a1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

