### PR TITLE
Add auto-sign whitelist for transaction approvals

### DIFF
--- a/src/options/views/Options.vue
+++ b/src/options/views/Options.vue
@@ -28,6 +28,16 @@
             <span class="sm-text">Seed phrase and private keys</span>
           </div>
         </span>
+        <span
+          class="tab"
+          :class="{ active: activeTab === 'authorizations' }"
+          @click="activeTab = 'authorizations'"
+        >
+          <div class="tab-detail">
+            <span class="lg-text">Authorizations</span>
+            <span class="sm-text">Manage auto-sign websites and functions</span>
+          </div>
+        </span>
       </div>
 
       <transition
@@ -172,6 +182,84 @@
             </div>
           </div>
         </div>
+        <div
+          v-else-if="activeTab === 'authorizations'"
+          key="authorizations"
+          class="settings-container"
+        >
+          <div class="top content">
+            <h2>Auto-sign authorizations</h2>
+            <p class="description">
+              Requests from authorized websites are signed directly when every
+              operation in the transaction matches one of these
+              contract/entry-point pairs.
+            </p>
+            <div
+              v-for="(authorization, i) in autoSignAuthorizations"
+              :key="`authorization-${i}`"
+              class="authorization-card"
+            >
+              <div class="input-group">
+                <div class="description">
+                  Website origin
+                </div>
+                <input
+                  v-model="authorization.origin"
+                  type="text"
+                  placeholder="https://example.com"
+                >
+              </div>
+              <div
+                v-for="(func, j) in authorization.functions"
+                :key="`authorization-function-${i}-${j}`"
+                class="authorization-function-row"
+              >
+                <input
+                  v-model="func.contractId"
+                  type="text"
+                  placeholder="Contract ID"
+                >
+                <input
+                  v-model="func.entryPoint"
+                  type="text"
+                  placeholder="Entry point"
+                >
+                <button
+                  class="small-danger-button"
+                  @click="removeAuthorizationFunction(i, j)"
+                >
+                  Remove
+                </button>
+              </div>
+              <div class="authorization-actions">
+                <button
+                  class="custom-button"
+                  @click="addAuthorizationFunction(i)"
+                >
+                  Add function
+                </button>
+                <button
+                  class="small-danger-button"
+                  @click="removeAuthorization(i)"
+                >
+                  Remove website
+                </button>
+              </div>
+            </div>
+            <button
+              class="custom-button"
+              @click="addAuthorization()"
+            >
+              Add website
+            </button>
+          </div>
+          <button
+            class="custom-button"
+            @click="updateAutoSignAuthorizations()"
+          >
+            Save authorizations
+          </button>
+        </div>
       </transition>
     </div>
   </div>
@@ -194,19 +282,61 @@ export default {
       accounts: [],
       networks: [],
       secretsVisible: false,
+      autoSignAuthorizations: [],
     };
   },
 
   mounted() {
     this.loadNetworks();
+    this.loadAutoSignAuthorizations();
   },
 
   methods: {
+    createNewAuthorization() {
+      return {
+        origin: "",
+        functions: [{ contractId: "", entryPoint: "" }],
+      };
+    },
+
+    normalizeOrigin(origin) {
+      const value = (origin || "").trim();
+      if (!value) return "";
+      try {
+        return new URL(value).origin;
+      } catch {
+        return value;
+      }
+    },
+
+    sanitizeAuthorizations(authorizations) {
+      return (authorizations || [])
+        .map((authorization) => {
+          const origin = this.normalizeOrigin(authorization.origin);
+          const functions = (authorization.functions || [])
+            .map((func) => ({
+              contractId: (func.contractId || "").trim(),
+              entryPoint: String(func.entryPoint || "").trim(),
+            }))
+            .filter((func) => func.contractId && func.entryPoint);
+          return { origin, functions };
+        })
+        .filter((authorization) => authorization.origin && authorization.functions.length);
+    },
+
     async loadNetworks() {
       this.networks = await this._getNetworks();
       this.networks.forEach((n) => {
         n.rpcNodesText = n.rpcNodes.join(",");
       });
+    },
+
+    async loadAutoSignAuthorizations() {
+      const authorizations = await this._getAutoSignAuthorizations();
+      this.autoSignAuthorizations = this.sanitizeAuthorizations(authorizations);
+      if (this.autoSignAuthorizations.length === 0) {
+        this.autoSignAuthorizations = [this.createNewAuthorization()];
+      }
     },
 
     async updateNetworks() {
@@ -221,6 +351,42 @@ export default {
         })
       );
       this.alertSuccess("Networks updated");
+    },
+
+    addAuthorization() {
+      this.autoSignAuthorizations.push(this.createNewAuthorization());
+    },
+
+    removeAuthorization(index) {
+      this.autoSignAuthorizations.splice(index, 1);
+      if (this.autoSignAuthorizations.length === 0) {
+        this.autoSignAuthorizations.push(this.createNewAuthorization());
+      }
+    },
+
+    addAuthorizationFunction(index) {
+      this.autoSignAuthorizations[index].functions.push({
+        contractId: "",
+        entryPoint: "",
+      });
+    },
+
+    removeAuthorizationFunction(authIndex, functionIndex) {
+      this.autoSignAuthorizations[authIndex].functions.splice(functionIndex, 1);
+      if (this.autoSignAuthorizations[authIndex].functions.length === 0) {
+        this.autoSignAuthorizations[authIndex].functions.push({
+          contractId: "",
+          entryPoint: "",
+        });
+      }
+    },
+
+    async updateAutoSignAuthorizations() {
+      const sanitized = this.sanitizeAuthorizations(this.autoSignAuthorizations);
+      await this._setAutoSignAuthorizations(sanitized);
+      this.autoSignAuthorizations =
+        sanitized.length > 0 ? sanitized : [this.createNewAuthorization()];
+      this.alertSuccess("Authorizations updated");
     },
 
     async viewSecrets() {
@@ -379,6 +545,35 @@ input {
   flex-direction: column;
   gap: 1em;
   width: 100%;
+}
+
+.authorization-card {
+  border: 1px solid var(--primary-dark-light);
+  border-radius: 0.7em;
+  padding: 1em;
+  margin-bottom: 1em;
+}
+
+.authorization-function-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.7em;
+  margin-bottom: 0.7em;
+}
+
+.authorization-actions {
+  display: flex;
+  gap: 0.7em;
+  justify-content: flex-end;
+}
+
+.small-danger-button {
+  border: 1px solid var(--kondor-red);
+  background: transparent;
+  color: var(--kondor-red);
+  border-radius: 0.5em;
+  padding: 0.4em 0.8em;
+  cursor: pointer;
 }
 
 .tabs button {

--- a/src/options/views/Options.vue
+++ b/src/options/views/Options.vue
@@ -7,37 +7,51 @@
         </div>
       </header>
 
-      <div class="tabs">
-        <span
-          class="tab"
+      <div class="page-intro">
+        <h2>Settings</h2>
+        <p class="description">
+          Manage network, wallet, and transaction authorization preferences.
+        </p>
+      </div>
+
+      <div
+        class="tabs"
+        role="tablist"
+        aria-label="Settings sections"
+      >
+        <button
+          class="tab-pill"
           :class="{ active: activeTab === 'networks' }"
+          role="tab"
+          type="button"
+          :aria-selected="activeTab === 'networks'"
           @click="activeTab = 'networks'"
         >
-          <div class="tab-detail">
-            <span class="lg-text">Networks</span>
-            <span class="sm-text">Network configuration</span>
-          </div>
-        </span>
-        <span
-          class="tab"
+          <span class="tab-pill-title">Networks</span>
+          <span class="tab-pill-subtitle">Network configuration</span>
+        </button>
+        <button
+          class="tab-pill"
           :class="{ active: activeTab === 'wallet' }"
+          role="tab"
+          type="button"
+          :aria-selected="activeTab === 'wallet'"
           @click="activeTab = 'wallet'"
         >
-          <div class="tab-detail">
-            <span class="lg-text">Wallet</span>
-            <span class="sm-text">Seed phrase and private keys</span>
-          </div>
-        </span>
-        <span
-          class="tab"
+          <span class="tab-pill-title">Wallet</span>
+          <span class="tab-pill-subtitle">Seed phrase and private keys</span>
+        </button>
+        <button
+          class="tab-pill"
           :class="{ active: activeTab === 'authorizations' }"
+          role="tab"
+          type="button"
+          :aria-selected="activeTab === 'authorizations'"
           @click="activeTab = 'authorizations'"
         >
-          <div class="tab-detail">
-            <span class="lg-text">Authorizations</span>
-            <span class="sm-text">Manage auto-sign websites and functions</span>
-          </div>
-        </span>
+          <span class="tab-pill-title">Authorizations</span>
+          <span class="tab-pill-subtitle">Auto-sign websites and functions</span>
+        </button>
       </div>
 
       <transition
@@ -84,12 +98,14 @@
               </div>
             </div>
           </div>
-          <button
-            class="custom-button"
-            @click="updateNetworks()"
-          >
-            Update Networks
-          </button>
+          <div class="section-actions">
+            <button
+              class="custom-button primary action-button"
+              @click="updateNetworks()"
+            >
+              Save network changes
+            </button>
+          </div>
         </div>
 
         <div
@@ -246,19 +262,23 @@
                 </button>
               </div>
             </div>
+            <div class="section-actions left">
+              <button
+                class="custom-button secondary action-button auto-width"
+                @click="addAuthorization()"
+              >
+                Add website
+              </button>
+            </div>
+          </div>
+          <div class="section-actions">
             <button
-              class="custom-button"
-              @click="addAuthorization()"
+              class="custom-button primary action-button"
+              @click="updateAutoSignAuthorizations()"
             >
-              Add website
+              Save authorizations
             </button>
           </div>
-          <button
-            class="custom-button"
-            @click="updateAutoSignAuthorizations()"
-          >
-            Save authorizations
-          </button>
         </div>
       </transition>
     </div>
@@ -409,38 +429,64 @@ input {
   color: var(--primary-gray);
 }
 
-/* tabs */
+.page-intro {
+  margin-bottom: 1.2rem;
+}
+
+.page-intro h2 {
+  margin: 0;
+}
+
 .tabs {
   display: flex;
-  gap: 1em;
-  margin-bottom: 2em;
-  margin-bottom: 2em;
-  justify-content: flex-start;
+  gap: 0.8rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
 }
-.tab {
+
+.tab-pill {
+  all: unset;
+  border: 1px solid var(--primary-dark-light);
+  background: #181818;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  min-width: 12rem;
   display: flex;
   flex-direction: column;
-  padding: 1em;
+  gap: 0.4rem;
   cursor: pointer;
-  border-radius: 0.5em;
-  transition: background-color 0.3s;
+  transition: border-color 0.2s ease, background-color 0.2s ease,
+    transform 0.2s ease;
 }
-.tab-detail {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5em;
+
+.tab-pill:hover {
+  border-color: var(--kondor-purple);
+  transform: translateY(-1px);
 }
-.lg-text {
-  font-size: 1.5em;
+
+.tab-pill.active {
+  background: var(--kondor-purple30);
+  border-color: var(--kondor-purple);
+}
+
+.tab-pill-title {
+  font-size: 1rem;
   font-weight: 600;
+  color: var(--primary-light);
 }
-.sm-text {
-  font-size: 1em;
+
+.tab-pill-subtitle {
+  font-size: 0.8rem;
+  color: var(--primary-gray);
 }
 .settings-container {
   display: flex;
   flex-direction: column;
-  gap: 2em;
+  gap: 1.4rem;
+  border: 1px solid var(--primary-dark-light);
+  border-radius: 0.9rem;
+  padding: 1.2rem;
+  background: #171717;
 }
 .container {
   margin: 0;
@@ -548,10 +594,11 @@ input {
 }
 
 .authorization-card {
-  border: 1px solid var(--primary-dark-light);
+  border: 1px solid #3a3a3a;
   border-radius: 0.7em;
   padding: 1em;
-  margin-bottom: 1em;
+  margin-bottom: 0.8em;
+  background: #131313;
 }
 
 .authorization-function-row {
@@ -564,7 +611,8 @@ input {
 .authorization-actions {
   display: flex;
   gap: 0.7em;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  flex-wrap: wrap;
 }
 
 .small-danger-button {
@@ -576,21 +624,25 @@ input {
   cursor: pointer;
 }
 
-.tabs button {
-  padding: 0.5em 1em;
-  font-size: 1em;
-  background-color: #333333;
-  border: none;
-  cursor: pointer;
-  transition: background-color 0.3s;
+.section-actions {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
 }
 
-.tabs button.active {
-  background-color: #444444;
+.section-actions.left {
+  justify-content: flex-start;
 }
 
-.tabs button:hover {
-  background-color: #555555;
+.action-button {
+  width: auto;
+  min-width: 12rem;
+  margin: 0;
+  height: auto;
+}
+
+.auto-width {
+  min-width: auto;
 }
 
 /* Transition styles */
@@ -607,6 +659,7 @@ input {
 @media (max-width: 768px) {
   .inside-container {
     width: 90%;
+    padding: 1.5rem;
   }
 
   .input-group {
@@ -623,6 +676,26 @@ input {
 
   .content .wide {
     flex-direction: column;
+  }
+
+  .tab-pill {
+    width: 100%;
+    min-width: auto;
+  }
+
+  .authorization-function-row {
+    grid-template-columns: 1fr;
+  }
+
+  .section-actions,
+  .section-actions.left {
+    justify-content: stretch;
+  }
+
+  .action-button,
+  .auto-width {
+    width: 100%;
+    min-width: auto;
   }
 }
 </style>

--- a/src/popup/views/2-SignSendTransaction.vue
+++ b/src/popup/views/2-SignSendTransaction.vue
@@ -1736,10 +1736,9 @@ export default {
 
     getAuthorizedFunctionsFromOperations(operations) {
       if (!Array.isArray(operations)) return [];
-      const allCallContract = operations.every((operation) => operation.call_contract);
-      if (!allCallContract) return [];
       const uniqueFunctions = {};
       operations.forEach((operation) => {
+        if (!operation.call_contract) return;
         const contractId = String(operation.call_contract.contract_id || "").trim();
         const entryPoint = String(operation.call_contract.entry_point ?? "").trim();
         if (!contractId || !entryPoint) return;

--- a/src/popup/views/2-SignSendTransaction.vue
+++ b/src/popup/views/2-SignSendTransaction.vue
@@ -16,6 +16,47 @@
       </div>
     </div>
     <div
+      v-if="authorizedFunctions.length > 0"
+      class="auto-sign-box"
+    >
+      <label class="auto-sign-checkbox">
+        <input
+          v-model="rememberAuthorization"
+          type="checkbox"
+        >
+        Remember this website and these functions for future calls
+      </label>
+      <div class="auto-sign-origin">
+        {{ requester.origin }}
+      </div>
+      <div class="auto-sign-functions">
+        <div
+          v-for="(func, i) in authorizedFunctions"
+          :key="`auth-func-${i}`"
+          class="auto-sign-function"
+        >
+          <div class="auto-sign-function-title">
+            Contract: {{ func.contractId }}
+          </div>
+          <div>Entry point: {{ func.entryPoint }}</div>
+        </div>
+      </div>
+      <button
+        class="auto-sign-info-button"
+        @click="toggleAutoSignExplanation"
+      >
+        {{ showAutoSignExplanation ? "Hide details" : "How does this work?" }}
+      </button>
+      <div
+        v-if="showAutoSignExplanation"
+        class="auto-sign-explanation"
+      >
+        If enabled, Kondor stores this website and the listed contract functions
+        locally. Future requests from this website that only call these same
+        functions are signed directly without opening this popup.
+      </div>
+    </div>
+    <div
       class="op-viewmore set-allowance-title"
       @click="toggleSettingAllowance()"
     >
@@ -599,6 +640,9 @@ export default {
       resolvedAddress: false,
       resolvedMessage: false,
       amount: 0,
+      rememberAuthorization: false,
+      showAutoSignExplanation: false,
+      authorizedFunctions: [],
     };
   },
   computed: {
@@ -701,6 +745,9 @@ export default {
       this.request = requests[0];
       this.requester = this.request.sender;
       this.typeRequest = this.send ? "send" : "sign";
+      this.authorizedFunctions = this.getAuthorizedFunctionsFromOperations(
+        this.request.args.transaction.operations
+      );
       this.kondorVersion = this.request.args.kondorVersion;
       if (this.kondorVersion) {
         this.kondorVersionBelow1 =
@@ -1634,6 +1681,13 @@ export default {
         } else {
           message.result = this.transaction.transaction;
         }
+        if (this.rememberAuthorization) {
+          try {
+            await this.rememberAutoSignAuthorization();
+          } catch (error) {
+            console.error("failed to save auto-sign authorization", error);
+          }
+        }
       } catch (err) {
         message.error = err.message;
       }
@@ -1674,6 +1728,71 @@ export default {
 
     toggleSettingAllowance() {
       this.settingAllowance = !this.settingAllowance;
+    },
+
+    toggleAutoSignExplanation() {
+      this.showAutoSignExplanation = !this.showAutoSignExplanation;
+    },
+
+    getAuthorizedFunctionsFromOperations(operations) {
+      if (!Array.isArray(operations)) return [];
+      const allCallContract = operations.every((operation) => operation.call_contract);
+      if (!allCallContract) return [];
+      const uniqueFunctions = {};
+      operations.forEach((operation) => {
+        const contractId = String(operation.call_contract.contract_id || "").trim();
+        const entryPoint = String(operation.call_contract.entry_point ?? "").trim();
+        if (!contractId || !entryPoint) return;
+        uniqueFunctions[`${contractId}:${entryPoint}`] = {
+          contractId,
+          entryPoint,
+        };
+      });
+      return Object.values(uniqueFunctions);
+    },
+
+    normalizeOrigin(origin) {
+      try {
+        return new URL(origin).origin;
+      } catch {
+        return origin;
+      }
+    },
+
+    async rememberAutoSignAuthorization() {
+      if (!this.requester || !this.requester.origin) return;
+      if (!this.authorizedFunctions.length) return;
+      const origin = this.normalizeOrigin(this.requester.origin);
+      const authorizations = await this._getAutoSignAuthorizations();
+      const index = authorizations.findIndex(
+        (authorization) =>
+          this.normalizeOrigin(authorization.origin) === this.normalizeOrigin(origin)
+      );
+      if (index < 0) {
+        authorizations.push({
+          origin,
+          functions: this.authorizedFunctions,
+        });
+      } else {
+        const mergedFunctions = {};
+        authorizations[index].functions.forEach((func) => {
+          const contractId = String(func.contractId || "").trim();
+          const entryPoint = String(func.entryPoint || "").trim();
+          if (!contractId || !entryPoint) return;
+          mergedFunctions[`${contractId}:${entryPoint}`] = {
+            contractId,
+            entryPoint,
+          };
+        });
+        this.authorizedFunctions.forEach((func) => {
+          mergedFunctions[`${func.contractId}:${func.entryPoint}`] = {
+            contractId: func.contractId,
+            entryPoint: func.entryPoint,
+          };
+        });
+        authorizations[index].functions = Object.values(mergedFunctions);
+      }
+      await this._setAutoSignAuthorizations(authorizations);
     },
 
     changeSpender() {
@@ -2383,6 +2502,72 @@ input:checked + .slider:before {
   width: 100%;
   padding: 1rem;
   box-sizing: border-box;
+}
+
+.auto-sign-box {
+  width: 92%;
+  margin-top: 1rem;
+  background-color: var(--primary-darker);
+  border: 1px solid var(--primary-dark-light);
+  border-radius: 0.8rem;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.auto-sign-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--primary-light);
+  font-size: 0.9rem;
+}
+
+.auto-sign-checkbox input[type="checkbox"] {
+  margin: 0;
+}
+
+.auto-sign-origin {
+  margin-top: 0.6rem;
+  color: var(--primary-gray);
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+
+.auto-sign-functions {
+  margin-top: 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.auto-sign-function {
+  background-color: var(--primary-dark-light);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.8rem;
+  color: var(--primary-gray);
+}
+
+.auto-sign-function-title {
+  color: var(--primary-light);
+  margin-bottom: 0.2rem;
+}
+
+.auto-sign-info-button {
+  margin-top: 0.7rem;
+  background: transparent;
+  color: var(--kondor-purple);
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.auto-sign-explanation {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--primary-gray);
 }
 
 .flex2 {

--- a/src/shared/components/Unlock.vue
+++ b/src/shared/components/Unlock.vue
@@ -32,9 +32,9 @@
 </template>
 
 <script>
-import { Signer } from "koilib";
 import Storage from "@/shared/mixins/Storage";
 import { HDKoinos } from "../../../lib/HDKoinos";
+import { decryptAccountsWithPassword } from "../../../lib/wallet";
 
 export default {
   name: "Unlock",
@@ -76,65 +76,34 @@ export default {
       try {
         const encryptedMnemonic = await this._getMnemonic(0);
         const encryptedAccounts = await this._getAccounts();
-        let accounts = [];
-        let mnemonic = null;
-        let hdKoinos = null;
-        if (encryptedMnemonic) {
-          mnemonic = await this.decrypt(encryptedMnemonic, this.password);
-          hdKoinos = new HDKoinos(mnemonic);
-        }
-        if (!encryptedAccounts || encryptedAccounts.length === 0) {
-          throw new Error("No accounts stored in the wallet");
-        }
-        accounts = await Promise.all(
-          encryptedAccounts.map(async (encAccount) => {
-            let account;
-            if (encAccount.keyPath) {
-              account = hdKoinos.deriveKey(encAccount);
-            } else {
-              let privateKey = "";
-              if (encAccount.encryptedPrivateKey) {
-                privateKey = await this.decrypt(
-                  encAccount.encryptedPrivateKey,
-                  this.password
-                );
-
-                const sig = Signer.fromWif(privateKey);
-                if (sig.getAddress() !== encAccount.address) {
-                  throw new Error(
-                    `Error in "${encAccount.name}". Expected address: ${
-                      encAccount.address
-                    }. Derived: ${sig.getAddress()}`
-                  );
-                }
-              }
-
-              account = {
-                public: {
-                  name: encAccount.name,
-                  address: encAccount.address,
-                },
-                private: {
-                  privateKey,
-                },
+        const { mnemonic, accounts: decryptedAccounts } =
+          await decryptAccountsWithPassword({
+            password: this.password,
+            encryptedMnemonic,
+            encryptedAccounts,
+            decryptText: this.decrypt,
+          });
+        const hdKoinos = mnemonic ? new HDKoinos(mnemonic) : null;
+        const accounts = decryptedAccounts.map((account) => {
+          const signers = (account.signers || []).map((signer) => {
+            if (!signer.keyPath || !hdKoinos) {
+              return {
+                name: signer.name,
+                address: signer.address,
+                privateKey: "",
               };
             }
-
+            const signerAcc = hdKoinos.deriveKey(signer);
             return {
-              ...account.public,
-              ...account.private,
-              signers: encAccount.signers
-                ? encAccount.signers.map((s) => {
-                  const signerAcc = hdKoinos.deriveKey(s);
-                  return {
-                    ...signerAcc.public,
-                    ...signerAcc.private,
-                  };
-                })
-                : [],
+              ...signerAcc.public,
+              ...signerAcc.private,
             };
-          })
-        );
+          });
+          return {
+            ...account,
+            signers,
+          };
+        });
 
         this.$store.state.mnemonic0 = mnemonic;
         this.$store.state.accounts = accounts;

--- a/src/shared/mixins/Storage.js
+++ b/src/shared/mixins/Storage.js
@@ -145,6 +145,21 @@ export default {
       return storage.getNetworks(strict);
     },
 
+    async _setAutoSignAuthorizations(authorizations) {
+      if (process.env.VUE_APP_ENV === "test") {
+        return this._write("autoSignAuthorizations", authorizations);
+      }
+      return storage.setAutoSignAuthorizations(authorizations);
+    },
+
+    async _getAutoSignAuthorizations(strict = false) {
+      if (process.env.VUE_APP_ENV === "test") {
+        const authorizations = await this._read("autoSignAuthorizations", strict);
+        return authorizations || [];
+      }
+      return storage.getAutoSignAuthorizations(strict);
+    },
+
     async _setTokens(tokens) {
       return this._write("tokens", tokens);
     },

--- a/src/shared/mixins/Storage.js
+++ b/src/shared/mixins/Storage.js
@@ -2,6 +2,7 @@
 import { Signer } from "koilib";
 import * as storage from "../../../lib/storage";
 import { HDKoinos } from "../../../lib/HDKoinos";
+import * as encryption from "../../../lib/encryption";
 import abiClaimMainnet from "../assets/abiClaimMainnet.json";
 // import abiKoinMainnet from "../assets/abiKoinMainnet.json";
 // import abiKoinHarbinger from "../assets/abiKoinHarbinger.json";
@@ -16,20 +17,6 @@ import abiNicknamesMainnet from "../assets/abiNicknamesMainnet.json";
 import abiNicknamesHarbinger from "../assets/abiNicknamesHarbinger.json";
 import abiKapNameService from "../assets/abiKapNameService.json";
 import abiFreeManaSharer from "../assets/abiFreeManaSharer.json";
-
-function toUint8Array(hexString) {
-  return new Uint8Array(
-    hexString
-      .match(/[\dA-F]{2}/gi) // separate into pairs
-      .map((s) => parseInt(s, 16)) // convert to integers
-  );
-}
-
-function toHexString(buffer) {
-  return Array.from(buffer)
-    .map((n) => `0${Number(n).toString(16)}`.slice(-2))
-    .join("");
-}
 
 export default {
   name: "Storage mixin",
@@ -540,89 +527,12 @@ export default {
       return this._read("currentIndexAccount", strict);
     },
 
-    // TODO: remove the following functions and replace them
-    // with the ones in storage.ts
-
-    async getOptsEncryption() {
-      let saltString = await this._read("salt", false);
-      let ivString = await this._read("iv", false);
-      if (!saltString || !ivString) {
-        saltString = toHexString(
-          window.crypto.getRandomValues(new Uint8Array(16))
-        );
-        ivString = toHexString(
-          window.crypto.getRandomValues(new Uint8Array(12))
-        );
-        await this._write("salt", saltString);
-        await this._write("iv", ivString);
-      }
-      const salt = toUint8Array(saltString).buffer;
-      const iv = toUint8Array(ivString).buffer;
-      return { salt, iv };
-    },
-
-    getKeyMaterial(password) {
-      let enc = new TextEncoder();
-      return window.crypto.subtle.importKey(
-        "raw",
-        enc.encode(password),
-        { name: "PBKDF2" },
-        false,
-        ["deriveBits", "deriveKey"]
-      );
-    },
-
-    async getKey(password, salt) {
-      const keyMaterial = await this.getKeyMaterial(password);
-      return window.crypto.subtle.deriveKey(
-        {
-          name: "PBKDF2",
-          salt: salt,
-          iterations: 100000,
-          hash: "SHA-256",
-        },
-        keyMaterial,
-        { name: "AES-GCM", length: 256 },
-        true,
-        ["encrypt", "decrypt"]
-      );
-    },
-
     async encrypt(data, password) {
-      const { salt, iv } = await this.getOptsEncryption();
-      const key = await this.getKey(password, salt);
-      const encoded = new TextEncoder().encode(data);
-
-      const bufferEncrypted = await window.crypto.subtle.encrypt(
-        { name: "AES-GCM", iv },
-        key,
-        encoded
-      );
-      return toHexString(new Uint8Array(bufferEncrypted));
+      return encryption.encryptText(data, password);
     },
 
     async decrypt(encrypted, password) {
-      const { salt, iv } = await this.getOptsEncryption();
-      const key = await this.getKey(password, salt);
-      let bufferEncrypted;
-      try {
-        bufferEncrypted = toUint8Array(encrypted);
-      } catch (error) {
-        throw new Error(`Invalid encryted value (${encrypted})`);
-      }
-
-      let decrypted;
-      try {
-        decrypted = await window.crypto.subtle.decrypt(
-          { name: "AES-GCM", iv },
-          key,
-          bufferEncrypted
-        );
-      } catch (error) {
-        throw new Error("Invalid password");
-      }
-
-      return new TextDecoder().decode(decrypted);
+      return encryption.decryptText(encrypted, password);
     },
   },
 };

--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -52,6 +52,7 @@ export default createStore({
       salt: "89c31dbb0175c54f2642ee582c610ff3",
       networks: storage.DEFAULT_NETWORKS,
       currentNetwork: storage.DEFAULT_CURRENT_NETWORK,
+      autoSignAuthorizations: [],
       "mainnet-abi-19GYjDBVXU7keLbYvMLazsGQn3GTWHjHkK": utils.tokenAbi,
       "harbinger-abi-1EdLyQ67LW6HVU1dWoceP4firtyz77e37Y": utils.tokenAbi,
     },

--- a/src/ts/background.ts
+++ b/src/ts/background.ts
@@ -9,7 +9,7 @@ import {
 } from "koilib";
 import { Messenger, Sender } from "kondor-js";
 import * as storage from "./storage";
-import { toUint8Array } from "./utils";
+import { decryptText } from "./encryption";
 import {
   decryptAccountsWithPassword,
   DecryptedWalletAccount,
@@ -132,47 +132,6 @@ async function readSession<T>(key: string): Promise<T | undefined> {
       resolve(result[key] as T | undefined);
     });
   });
-}
-
-async function getKeyMaterial(password: string) {
-  const enc = new TextEncoder();
-  return crypto.subtle.importKey(
-    "raw",
-    enc.encode(password),
-    { name: "PBKDF2" },
-    false,
-    ["deriveBits", "deriveKey"]
-  );
-}
-
-async function getKey(password: string, salt: ArrayBufferLike) {
-  const keyMaterial = await getKeyMaterial(password);
-  return crypto.subtle.deriveKey(
-    {
-      name: "PBKDF2",
-      salt,
-      iterations: 100000,
-      hash: "SHA-256",
-    },
-    keyMaterial,
-    { name: "AES-GCM", length: 256 },
-    true,
-    ["encrypt", "decrypt"]
-  );
-}
-
-async function decryptText(encrypted: string, password: string): Promise<string> {
-  const saltString = await storage.read<string>("salt", true);
-  const ivString = await storage.read<string>("iv", true);
-  const salt = toUint8Array(saltString).buffer;
-  const iv = toUint8Array(ivString).buffer;
-  const key = await getKey(password, salt);
-  const decrypted = await crypto.subtle.decrypt(
-    { name: "AES-GCM", iv },
-    key,
-    toUint8Array(encrypted)
-  );
-  return new TextDecoder().decode(decrypted);
 }
 
 async function getAccountsForAutoSign(

--- a/src/ts/background.ts
+++ b/src/ts/background.ts
@@ -9,8 +9,12 @@ import {
 } from "koilib";
 import { Messenger, Sender } from "kondor-js";
 import * as storage from "./storage";
-import { HDKoinos } from "./HDKoinos";
 import { toUint8Array } from "./utils";
+import {
+  decryptAccountsWithPassword,
+  DecryptedWalletAccount,
+  EncryptedWalletAccount,
+} from "./wallet";
 
 const EXPIRATION_ID = 30 * 60 * 1000; // 30 minutes
 
@@ -22,19 +26,6 @@ interface AutoSignRequestArgs {
     signerAddress?: string;
     transaction: TransactionJson;
   };
-}
-
-interface EncryptedAccount {
-  name: string;
-  address: string;
-  keyPath?: string;
-  encryptedPrivateKey?: string;
-}
-
-interface AccountWithPrivateKey {
-  name: string;
-  address: string;
-  privateKey: string;
 }
 
 const getIds = async () => {
@@ -186,51 +177,21 @@ async function decryptText(encrypted: string, password: string): Promise<string>
 
 async function getAccountsForAutoSign(
   password: string
-): Promise<AccountWithPrivateKey[]> {
-  const encryptedAccounts =
-    (await storage.read<EncryptedAccount[]>("accounts", false)) || [];
-  if (!encryptedAccounts.length) {
-    throw new Error("AUTO_SIGN_FALLBACK: no accounts found");
-  }
-  const encryptedMnemonic = await storage.read<string>("mnemonic0", false);
-  let hdKoinos: HDKoinos | null = null;
-  if (encryptedMnemonic) {
-    const mnemonic = await decryptText(encryptedMnemonic, password);
-    hdKoinos = new HDKoinos(mnemonic);
-  }
-
-  return Promise.all(
-    encryptedAccounts.map(async (account) => {
-      if (account.keyPath) {
-        if (!hdKoinos) {
-          throw new Error(
-            `AUTO_SIGN_FALLBACK: missing mnemonic for ${account.address}`
-          );
-        }
-        const derived = hdKoinos.deriveKey({
-          name: account.name,
-          keyPath: account.keyPath,
-          address: account.address,
-        });
-        return {
-          name: account.name,
-          address: account.address,
-          privateKey: derived.private.privateKey,
-        };
-      }
-      if (!account.encryptedPrivateKey) {
-        throw new Error(
-          `AUTO_SIGN_FALLBACK: account ${account.address} has no private key`
-        );
-      }
-      const privateKey = await decryptText(account.encryptedPrivateKey, password);
-      return {
-        name: account.name,
-        address: account.address,
-        privateKey,
-      };
-    })
+) {
+  const encryptedAccounts = await storage.read<EncryptedWalletAccount[]>(
+    "accounts",
+    false
   );
+  const encryptedMnemonic = await storage.read<string>("mnemonic0", false);
+  const { accounts } = await decryptAccountsWithPassword({
+    password,
+    encryptedMnemonic,
+    encryptedAccounts,
+    decryptText,
+    requirePrivateKey: true,
+    errorPrefix: "AUTO_SIGN_FALLBACK",
+  });
+  return accounts;
 }
 
 async function autoSignTransaction(
@@ -239,7 +200,7 @@ async function autoSignTransaction(
   const password = await readSession<string>("password0");
   if (!password) throw new Error("AUTO_SIGN_FALLBACK: wallet is locked");
 
-  let accounts: AccountWithPrivateKey[];
+  let accounts: DecryptedWalletAccount[];
   try {
     accounts = await getAccountsForAutoSign(password);
   } catch (error) {

--- a/src/ts/background.ts
+++ b/src/ts/background.ts
@@ -9,10 +9,33 @@ import {
 } from "koilib";
 import { Messenger, Sender } from "kondor-js";
 import * as storage from "./storage";
+import { HDKoinos } from "./HDKoinos";
+import { toUint8Array } from "./utils";
 
 const EXPIRATION_ID = 30 * 60 * 1000; // 30 minutes
 
 let tabIdRequester: number | undefined;
+
+interface AutoSignRequestArgs {
+  command: "signer:signTransaction" | "signer:sendTransaction";
+  args: {
+    signerAddress?: string;
+    transaction: TransactionJson;
+  };
+}
+
+interface EncryptedAccount {
+  name: string;
+  address: string;
+  keyPath?: string;
+  encryptedPrivateKey?: string;
+}
+
+interface AccountWithPrivateKey {
+  name: string;
+  address: string;
+  privateKey: string;
+}
 
 const getIds = async () => {
   const ids =
@@ -110,6 +133,172 @@ async function getChainIdFromStorage(
   const network = networks.find((n) => n.tag === networkTag);
   if (!network) throw new Error(`network ${networkTag} not found`);
   return network.chainId;
+}
+
+async function readSession<T>(key: string): Promise<T | undefined> {
+  return new Promise((resolve) => {
+    chrome.storage.session.get([key], (result) => {
+      resolve(result[key] as T | undefined);
+    });
+  });
+}
+
+async function getKeyMaterial(password: string) {
+  const enc = new TextEncoder();
+  return crypto.subtle.importKey(
+    "raw",
+    enc.encode(password),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits", "deriveKey"]
+  );
+}
+
+async function getKey(password: string, salt: ArrayBufferLike) {
+  const keyMaterial = await getKeyMaterial(password);
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"]
+  );
+}
+
+async function decryptText(encrypted: string, password: string): Promise<string> {
+  const saltString = await storage.read<string>("salt", true);
+  const ivString = await storage.read<string>("iv", true);
+  const salt = toUint8Array(saltString).buffer;
+  const iv = toUint8Array(ivString).buffer;
+  const key = await getKey(password, salt);
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    toUint8Array(encrypted)
+  );
+  return new TextDecoder().decode(decrypted);
+}
+
+async function getAccountsForAutoSign(
+  password: string
+): Promise<AccountWithPrivateKey[]> {
+  const encryptedAccounts =
+    (await storage.read<EncryptedAccount[]>("accounts", false)) || [];
+  if (!encryptedAccounts.length) {
+    throw new Error("AUTO_SIGN_FALLBACK: no accounts found");
+  }
+  const encryptedMnemonic = await storage.read<string>("mnemonic0", false);
+  let hdKoinos: HDKoinos | null = null;
+  if (encryptedMnemonic) {
+    const mnemonic = await decryptText(encryptedMnemonic, password);
+    hdKoinos = new HDKoinos(mnemonic);
+  }
+
+  return Promise.all(
+    encryptedAccounts.map(async (account) => {
+      if (account.keyPath) {
+        if (!hdKoinos) {
+          throw new Error(
+            `AUTO_SIGN_FALLBACK: missing mnemonic for ${account.address}`
+          );
+        }
+        const derived = hdKoinos.deriveKey({
+          name: account.name,
+          keyPath: account.keyPath,
+          address: account.address,
+        });
+        return {
+          name: account.name,
+          address: account.address,
+          privateKey: derived.private.privateKey,
+        };
+      }
+      if (!account.encryptedPrivateKey) {
+        throw new Error(
+          `AUTO_SIGN_FALLBACK: account ${account.address} has no private key`
+        );
+      }
+      const privateKey = await decryptText(account.encryptedPrivateKey, password);
+      return {
+        name: account.name,
+        address: account.address,
+        privateKey,
+      };
+    })
+  );
+}
+
+async function autoSignTransaction(
+  inputArgs: AutoSignRequestArgs
+): Promise<unknown> {
+  const password = await readSession<string>("password0");
+  if (!password) throw new Error("AUTO_SIGN_FALLBACK: wallet is locked");
+
+  let accounts: AccountWithPrivateKey[];
+  try {
+    accounts = await getAccountsForAutoSign(password);
+  } catch (error) {
+    const errorMessage = (error as Error).message || "account decryption failed";
+    if (errorMessage.startsWith("AUTO_SIGN_FALLBACK:")) throw error;
+    throw new Error(`AUTO_SIGN_FALLBACK: ${errorMessage}`);
+  }
+  const signerAddress = inputArgs.args.signerAddress || accounts[0]?.address;
+  if (!signerAddress)
+    throw new Error("AUTO_SIGN_FALLBACK: no signer address available");
+  const account = accounts.find((a) => a.address === signerAddress);
+  if (!account) {
+    throw new Error(
+      `AUTO_SIGN_FALLBACK: signer address ${signerAddress} not found in wallet`
+    );
+  }
+
+  const transaction = JSON.parse(
+    JSON.stringify(inputArgs.args.transaction)
+  ) as TransactionJson;
+  if (!transaction.header) {
+    transaction.header = { payer: signerAddress };
+  }
+  if (!transaction.header.payer) {
+    transaction.header.payer = signerAddress;
+  }
+
+  const networks = await storage.getNetworks();
+  let network = transaction.header.chain_id
+    ? networks.find((n) => n.chainId === transaction.header!.chain_id)
+    : undefined;
+  if (!network) {
+    const currentNetwork = await storage.getCurrentNetwork();
+    network = networks.find((n) => n.tag === currentNetwork);
+  }
+  if (!network) throw new Error("AUTO_SIGN_FALLBACK: current network not found");
+  if (!transaction.header.chain_id) {
+    transaction.header.chain_id = network.chainId;
+  }
+
+  const provider = new Provider(network.rpcNodes);
+  const preparedTransaction = await Transaction.prepareTransaction(
+    transaction,
+    provider
+  );
+
+  const signer = Signer.fromWif(account.privateKey);
+  signer.provider = provider;
+  signer.rcOptions = { estimateRc: false };
+  await signer.signTransaction(preparedTransaction);
+
+  if (inputArgs.command === "signer:sendTransaction") {
+    const receipt = await provider.sendTransaction(preparedTransaction, true);
+    return {
+      receipt,
+      transaction: preparedTransaction,
+    };
+  }
+  return preparedTransaction;
 }
 
 function checkKondorWindows(): Promise<chrome.windows.Window[]> {
@@ -339,6 +528,10 @@ const messenger = new Messenger({
           };
           const provider = await getProvider(network);
           result = await provider.invokeGetContractMetadata(contractId);
+          break;
+        }
+        case "signer:autoSignTransaction": {
+          result = await autoSignTransaction(args as AutoSignRequestArgs);
           break;
         }
 

--- a/src/ts/content.ts
+++ b/src/ts/content.ts
@@ -1,4 +1,5 @@
 import { Messenger } from "kondor-js";
+import * as storage from "./storage";
 
 interface Event {
   data: {
@@ -12,6 +13,19 @@ interface Event {
     postMessage: (data: unknown, target: string) => void;
   };
   origin: string;
+}
+
+interface CallContractOperation {
+  call_contract?: {
+    contract_id?: string;
+    entry_point?: string | number;
+  };
+}
+
+interface TransactionArgs {
+  transaction?: {
+    operations?: CallContractOperation[];
+  };
 }
 
 declare const window: {
@@ -61,6 +75,47 @@ async function preparePopup() {
   while (!popupReady) await new Promise((r) => setTimeout(r, 20));
 }
 
+function normalizeOrigin(origin: string): string {
+  try {
+    return new URL(origin).origin;
+  } catch {
+    return origin;
+  }
+}
+
+function getRequestedFunctions(args: unknown) {
+  const txArgs = args as TransactionArgs;
+  const operations = txArgs.transaction?.operations || [];
+  if (!operations.length) return [];
+  const requestedFunctions = [];
+  for (let i = 0; i < operations.length; i += 1) {
+    const callContract = operations[i].call_contract;
+    if (!callContract || !callContract.contract_id) return null;
+    const contractId = String(callContract.contract_id).trim();
+    const entryPoint = String(callContract.entry_point ?? "").trim();
+    if (!contractId || !entryPoint) return null;
+    requestedFunctions.push({ contractId, entryPoint });
+  }
+  return requestedFunctions;
+}
+
+async function isAutoSignAllowed(origin: string, args: unknown): Promise<boolean> {
+  const requestedFunctions = getRequestedFunctions(args);
+  if (!requestedFunctions || requestedFunctions.length === 0) return false;
+  const authorizations = await storage.getAutoSignAuthorizations();
+  const authorization = authorizations.find(
+    (item) => normalizeOrigin(item.origin) === normalizeOrigin(origin)
+  );
+  if (!authorization || !authorization.functions?.length) return false;
+  return requestedFunctions.every((requestedFunction) =>
+    authorization.functions.some(
+      (allowed) =>
+        allowed.contractId === requestedFunction.contractId &&
+        String(allowed.entryPoint) === requestedFunction.entryPoint
+    )
+  );
+}
+
 const messenger: Messenger = new Messenger({
   onExtensionRequest: async (message) => {
     const { command } = message;
@@ -78,6 +133,28 @@ const messenger: Messenger = new Messenger({
     const isBackgroundCommand = backgroundCommands.includes(command!);
     const isPopupCommand = popupCommands.includes(command!);
     if (!isBackgroundCommand && !isPopupCommand) return undefined;
+
+    const isTransactionPopupCommand =
+      command === "signer:signTransaction" || command === "signer:sendTransaction";
+    if (isTransactionPopupCommand && (await isAutoSignAllowed(event.origin, args))) {
+      try {
+        return messenger.sendExtensionMessage(
+          "background",
+          "signer:autoSignTransaction",
+          {
+            command,
+            args,
+          },
+          {
+            ping: true,
+            pingTimeout: 2000,
+          }
+        );
+      } catch (error) {
+        const errorMessage = (error as Error).message || "";
+        if (!errorMessage.startsWith("AUTO_SIGN_FALLBACK:")) throw error;
+      }
+    }
 
     if (isPopupCommand) {
       popupReady = false;

--- a/src/ts/encryption.ts
+++ b/src/ts/encryption.ts
@@ -1,15 +1,17 @@
 import * as storage from "./storage";
 import { toHexString, toUint8Array } from "./utils";
 
-async function getOptsEncryption(): Promise<{
+export async function getOptsEncryption(): Promise<{
   salt: ArrayBufferLike;
   iv: ArrayBufferLike;
 }> {
   let saltString = await storage.read<string>("salt", false);
   let ivString = await storage.read<string>("iv", false);
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi) throw new Error("Crypto API not available");
   if (!saltString || !ivString) {
-    saltString = toHexString(window.crypto.getRandomValues(new Uint8Array(16)));
-    ivString = toHexString(window.crypto.getRandomValues(new Uint8Array(12)));
+    saltString = toHexString(cryptoApi.getRandomValues(new Uint8Array(16)));
+    ivString = toHexString(cryptoApi.getRandomValues(new Uint8Array(12)));
     await storage.write("salt", saltString);
     await storage.write("iv", ivString);
   }
@@ -18,9 +20,11 @@ async function getOptsEncryption(): Promise<{
   return { salt, iv };
 }
 
-async function getKeyMaterial(password: string) {
+export async function getKeyMaterial(password: string) {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi) throw new Error("Crypto API not available");
   let enc = new TextEncoder();
-  return window.crypto.subtle.importKey(
+  return cryptoApi.subtle.importKey(
     "raw",
     enc.encode(password),
     { name: "PBKDF2" },
@@ -29,9 +33,11 @@ async function getKeyMaterial(password: string) {
   );
 }
 
-async function getKey(password: string, salt: ArrayBufferLike) {
+export async function getKey(password: string, salt: ArrayBufferLike) {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi) throw new Error("Crypto API not available");
   const keyMaterial = await getKeyMaterial(password);
-  return window.crypto.subtle.deriveKey(
+  return cryptoApi.subtle.deriveKey(
     {
       name: "PBKDF2",
       salt,
@@ -45,16 +51,16 @@ async function getKey(password: string, salt: ArrayBufferLike) {
   );
 }
 
-export async function encrypt(
-  data: Record<string, unknown>,
+export async function encryptText(
+  data: string,
   password: string
 ): Promise<string> {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi) throw new Error("Crypto API not available");
   const { salt, iv } = await getOptsEncryption();
   const key = await getKey(password, salt);
-  const message = JSON.stringify(data);
-  const encoded = new TextEncoder().encode(message);
-
-  const bufferEncrypted = await window.crypto.subtle.encrypt(
+  const encoded = new TextEncoder().encode(data);
+  const bufferEncrypted = await cryptoApi.subtle.encrypt(
     { name: "AES-GCM", iv },
     key,
     encoded
@@ -62,10 +68,12 @@ export async function encrypt(
   return toHexString(new Uint8Array(bufferEncrypted));
 }
 
-export async function decrypt(
+export async function decryptText(
   encrypted: string,
   password: string
-): Promise<Record<string, unknown>> {
+): Promise<string> {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi) throw new Error("Crypto API not available");
   const { salt, iv } = await getOptsEncryption();
   const key = await getKey(password, salt);
   let bufferEncrypted;
@@ -77,7 +85,7 @@ export async function decrypt(
 
   let decrypted;
   try {
-    decrypted = await window.crypto.subtle.decrypt(
+    decrypted = await cryptoApi.subtle.decrypt(
       { name: "AES-GCM", iv },
       key,
       bufferEncrypted
@@ -85,9 +93,23 @@ export async function decrypt(
   } catch (error) {
     throw new Error("Invalid password");
   }
+  return new TextDecoder().decode(decrypted);
+}
 
+export async function encrypt(
+  data: Record<string, unknown>,
+  password: string
+): Promise<string> {
+  const message = JSON.stringify(data);
+  return encryptText(message, password);
+}
+
+export async function decrypt(
+  encrypted: string,
+  password: string
+): Promise<Record<string, unknown>> {
   try {
-    const message = new TextDecoder().decode(decrypted);
+    const message = await decryptText(encrypted, password);
     return JSON.parse(message);
   } catch (error) {
     throw new Error("Decrypted value cannot be decoded and parsed to JSON");

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -57,6 +57,16 @@ export interface Network {
   manaMeter?: string;
 }
 
+export interface AutoSignFunctionAuthorization {
+  contractId: string;
+  entryPoint: string;
+}
+
+export interface AutoSignWebsiteAuthorization {
+  origin: string;
+  functions: AutoSignFunctionAuthorization[];
+}
+
 export const DEFAULT_NETWORKS: Network[] = [
   {
     name: "Koinos Mainnet",
@@ -146,4 +156,44 @@ export async function getNetworks(strict = true): Promise<Network[]> {
   });
 
   return networks!;
+}
+
+export async function setAutoSignAuthorizations(
+  authorizations: AutoSignWebsiteAuthorization[]
+): Promise<void> {
+  const sanitized = (authorizations || [])
+    .map((authorization) => {
+      const origin = (authorization.origin || "").trim();
+      const functions = (authorization.functions || [])
+        .map((f) => ({
+          contractId: (f.contractId || "").trim(),
+          entryPoint: String(f.entryPoint || "").trim(),
+        }))
+        .filter((f) => f.contractId && f.entryPoint);
+      return { origin, functions };
+    })
+    .filter((authorization) => authorization.origin && authorization.functions.length);
+  return write("autoSignAuthorizations", sanitized);
+}
+
+export async function getAutoSignAuthorizations(
+  strict = false
+): Promise<AutoSignWebsiteAuthorization[]> {
+  const authorizations = await read<AutoSignWebsiteAuthorization[]>(
+    "autoSignAuthorizations",
+    strict
+  );
+  if (!authorizations || !Array.isArray(authorizations)) return [];
+  return authorizations
+    .map((authorization) => {
+      const origin = (authorization.origin || "").trim();
+      const functions = (authorization.functions || [])
+        .map((f) => ({
+          contractId: (f.contractId || "").trim(),
+          entryPoint: String(f.entryPoint || "").trim(),
+        }))
+        .filter((f) => f.contractId && f.entryPoint);
+      return { origin, functions };
+    })
+    .filter((authorization) => authorization.origin && authorization.functions.length);
 }

--- a/src/ts/wallet.ts
+++ b/src/ts/wallet.ts
@@ -1,0 +1,121 @@
+import { Signer } from "koilib";
+import { HDKoinos } from "./HDKoinos";
+
+export interface EncryptedWalletSigner {
+  name: string;
+  address: string;
+  keyPath?: string;
+  encryptedPrivateKey?: string;
+}
+
+export interface EncryptedWalletAccount {
+  name: string;
+  address: string;
+  keyPath?: string;
+  encryptedPrivateKey?: string;
+  signers?: EncryptedWalletSigner[];
+}
+
+export interface DecryptedWalletAccount {
+  name: string;
+  address: string;
+  keyPath?: string;
+  privateKey: string;
+  signers: EncryptedWalletSigner[];
+}
+
+interface DecryptAccountsOptions {
+  password: string;
+  encryptedMnemonic?: string | null;
+  encryptedAccounts?: EncryptedWalletAccount[] | null;
+  decryptText: (encrypted: string, password: string) => Promise<string>;
+  requirePrivateKey?: boolean;
+  errorPrefix?: string;
+}
+
+function getWalletErrorMessage(message: string, prefix?: string): string {
+  if (!prefix) return message;
+  return `${prefix}: ${message}`;
+}
+
+export async function decryptAccountsWithPassword(
+  options: DecryptAccountsOptions
+): Promise<{ mnemonic: string | null; accounts: DecryptedWalletAccount[] }> {
+  const {
+    password,
+    encryptedMnemonic,
+    encryptedAccounts,
+    decryptText,
+    requirePrivateKey = false,
+    errorPrefix,
+  } = options;
+  if (!encryptedAccounts || encryptedAccounts.length === 0) {
+    throw new Error(
+      getWalletErrorMessage("No accounts stored in the wallet", errorPrefix)
+    );
+  }
+
+  let mnemonic: string | null = null;
+  let hdKoinos: HDKoinos | null = null;
+  if (encryptedMnemonic) {
+    mnemonic = await decryptText(encryptedMnemonic, password);
+    hdKoinos = new HDKoinos(mnemonic);
+  }
+
+  const accounts = await Promise.all(
+    encryptedAccounts.map(async (encryptedAccount) => {
+      if (encryptedAccount.keyPath) {
+        if (!hdKoinos) {
+          throw new Error(
+            getWalletErrorMessage(
+              `Missing mnemonic for ${encryptedAccount.address}`,
+              errorPrefix
+            )
+          );
+        }
+        const account = hdKoinos.deriveKey({
+          name: encryptedAccount.name,
+          keyPath: encryptedAccount.keyPath,
+          address: encryptedAccount.address,
+        });
+        return {
+          ...account.public,
+          ...account.private,
+          signers: encryptedAccount.signers || [],
+        };
+      }
+
+      let privateKey = "";
+      if (encryptedAccount.encryptedPrivateKey) {
+        privateKey = await decryptText(encryptedAccount.encryptedPrivateKey, password);
+        const signer = Signer.fromWif(privateKey);
+        if (signer.getAddress() !== encryptedAccount.address) {
+          throw new Error(
+            getWalletErrorMessage(
+              `Error in "${encryptedAccount.name}". Expected address: ${encryptedAccount.address}. Derived: ${signer.getAddress()}`,
+              errorPrefix
+            )
+          );
+        }
+      }
+
+      if (requirePrivateKey && !privateKey) {
+        throw new Error(
+          getWalletErrorMessage(
+            `Account ${encryptedAccount.address} has no private key`,
+            errorPrefix
+          )
+        );
+      }
+
+      return {
+        name: encryptedAccount.name,
+        address: encryptedAccount.address,
+        privateKey,
+        signers: encryptedAccount.signers || [],
+      };
+    })
+  );
+
+  return { mnemonic, accounts };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "src/ts/storage.ts",
+    "src/ts/encryption.ts",
     "src/ts/HDKoinos.ts",
     "src/ts/utils.ts",
     "src/ts/wallet.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,10 @@
     "module": "ES6",
     "outDir": "lib"
   },
-  "files": ["src/ts/storage.ts", "src/ts/HDKoinos.ts", "src/ts/utils.ts"]
+  "files": [
+    "src/ts/storage.ts",
+    "src/ts/HDKoinos.ts",
+    "src/ts/utils.ts",
+    "src/ts/wallet.ts"
+  ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a persisted auto-sign whitelist keyed by website origin with allowed `(contract_id, entry_point)` pairs
- add a content-script gate plus background auto-sign path so matching calls can be signed/sent without opening the popup
- add popup UI to remember website/function permissions with an expandable explanation
- add options-page CRUD management for website authorizations and allowed functions
- improve options page UX with clear pill-style tab navigation and better action button hierarchy/layout
- refactor duplicated account decryption logic into reusable wallet helper used by background auto-sign and unlock flow
- centralize shared crypto helpers in `src/ts/encryption.ts` and reuse them from `Storage.js` and `background.ts`

## Validation
- `yarn build:ts`
- `yarn lint --no-fix` (warnings only from existing `tokenPriceService.js`)
- manual verification in popup and options pages

## Walkthrough artifacts
[auto_sign_whitelist_exact_values_demo.mp4](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauto_sign_whitelist_exact_values_demo.mp4)
[options_page_ux_improvements_final_demo.mp4](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foptions_page_ux_improvements_final_demo.mp4)
[unlock_refactor_smoke_test_demo.mp4](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funlock_refactor_smoke_test_demo.mp4)
[Popup remember section](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpopup_remember_section.webp)
[Options authorizations tab](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foptions_authorizations_saved.webp)
[Networks tab save button](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foptions_networks_save_button.webp)
[Authorizations tab button layout](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foptions_authorizations_buttons.webp)
[Sign transaction view after unlock](https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funlock_refactor_loaded_view.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f19b2b-6101-46dc-a329-26f4d10ccbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

